### PR TITLE
DEXON Derivation Path Explanation

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -21,8 +21,32 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     testnet: {
-      provider: new HDWalletProvider(mnemonic,
-        "http://testnet.dexon.org:8545", 0, 1, true, "m/44'/237'/0'/0/"),
+      provider: new HDWalletProvider(
+        mnemonic,
+        /*
+        * mnemonic is from BIP39
+        * BIP39 is the method for deriving private keys from mnemonic words.
+        * With different derivation path,
+        * we can generate different private keys from the same set of mnemonic word
+        */
+        "http://testnet.dexon.org:8545",
+        0,
+        1,
+        true,
+        "m/44'/237'/0'/0/",
+        /*
+        * Derivation Path <= "m/44'/237'/0'/0/"
+        * 
+        * BIP44 defines how what derivation path should be like,
+        * and it relies on coin type.
+        * 
+        * Ethereum is registered as 60 『"m/44'/60'/0'/0/"』,
+        * while DEXON is registered as 237 『"m/44'/237'/0'/0/"』.
+        * 
+        * Therefore, given the same set of mnemonic words,
+        * the addresses for Ethereum and DEXON are different.
+        */
+      ),
       network_id: "*"
     },
     development: {


### PR DESCRIPTION
## Why
To make it clear of what happens under the hood with `mnemonic` and `Derivation Path`.
That way, it would be much easier for people to get them onboard on DEXON with ease.

## Reference

[BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) is the method for deriving private keys from mnemonic words. With different derivation path, we can generate different private keys from the same set of mnemonic words.

[BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) defines how what derivation path should be like, and it relies on coin type. Ethereum is registered as `60`, while DEXON is registered as `237`. Therefore, given the same set of mnemonic words, the addresses for Ethereum and DEXON are different.
